### PR TITLE
Allow more rows to be used in the keypad

### DIFF
--- a/src/Keypad.h
+++ b/src/Keypad.h
@@ -81,7 +81,7 @@ public:
 	virtual void pin_write(byte pinNum, boolean level) { digitalWrite(pinNum, level); }
 	virtual int  pin_read(byte pinNum) { return digitalRead(pinNum); }
 
-	uint bitMap[MAPSIZE];	// 10 row x 16 column array of bits. Except Due which has 32 columns.
+	uint bitMap[MAPSIZE];	// 12 row x 16 column array of bits. Except Due which has 32 columns.
 	Key key[LIST_MAX];
 	unsigned long holdTimer;
 


### PR DESCRIPTION
If your keypad matrix has more than 10 rows there will be scanning issues. Raising MAPSIZE to 12 allows for two more rows to be used. Theoretically the maximum number of rows should be 16, accounting for 256 possible key values, but the practical limit is not known for me. 

Notice that with big keyboards is not always possible to arrange the key matrix using more columns than rows, i.e., for a 140 keys keyboard is not optimal to use 14 columns x10 rows but something like 12x12 or 13x11.
